### PR TITLE
release: bump version to 1.52.1

### DIFF
--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -32,7 +32,7 @@ await build({
     // package.json properties
     name: "lago-javascript-client",
     sideEffects: false,
-    version: "v1.52.0",
+    version: "v1.52.1",
     description: "Lago JavaScript API Client",
     repository: {
       type: "git",


### PR DESCRIPTION
Bumps the published package version to `1.52.1`.

Matches `lago-go-client` [v1.52.1](https://github.com/getlago/lago-go-client/releases/tag/v1.52.1).